### PR TITLE
Update to 6.6.0: sync with kf6-kimageformats

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  kimageformats-6.4.0.tar.xz: 1049219b7ddca2366c0b2703635ae725556ad915
+  kimageformats-6.6.0.tar.xz: 45b11353488622cd573517920bca3a7ef5dd2ba3

--- a/kf6-kimageformats.spec
+++ b/kf6-kimageformats.spec
@@ -18,7 +18,7 @@
 #define git 20240217
 
 Name: kf6-kimageformats
-Version: 6.4.0
+Version: 6.6.0
 Release: %{?git:0.%{git}.}1%{?extrarelsuffix}
 %if 0%{?git:1}
 Source0: https://invent.kde.org/frameworks/kimageformats/-/archive/master/kimageformats-master.tar.bz2#/kimageformats-%{git}.tar.bz2


### PR DESCRIPTION
Update KImageFormats to version 6.6.0.
Despite warning at the top of [the specfile of kf6-kimageformats](https://github.com/OpenMandrivaAssociation/kf6-kimageformats/blob/master/kf6-kimageformats.spec), the twin package in the restricted repository was not updated.